### PR TITLE
Add Ruby gem scaffolding, update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,17 @@
+/.bundle/
+/.yardoc
+/Gemfile.lock
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/
+/bin/
+
+# rspec failure tracking
+.rspec_status
+
 /.galaxy-roles
 /.ruby-version
 /.vagrant

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--format documentation
+--color

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,14 @@
 ---
 dist: trusty
+sudo: false
 language: ruby
+
 ruby: 2.4.1
+
+rvm:
+  - 2.4.1
+
+before_install: gem install bundler -v 1.15.4
 
 script: /bin/true
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,7 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
 
-# gem "rails"
+git_source(:github) {|revolution| "https://github.com/grindrlabs/revolution" }
+
+# TODO Specify your gem's dependencies in revolution.gemspec
+# gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,6 @@
+require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+task :default => :spec

--- a/lib/revolution.rb
+++ b/lib/revolution.rb
@@ -1,0 +1,5 @@
+require "revolution/version"
+
+module Revolution
+  # TODO
+end

--- a/lib/revolution/version.rb
+++ b/lib/revolution/version.rb
@@ -1,0 +1,3 @@
+module Revolution
+  VERSION = "0.0.1"
+end

--- a/spec/revolution_spec.rb
+++ b/spec/revolution_spec.rb
@@ -1,0 +1,11 @@
+require "spec_helper"
+
+RSpec.describe Revolution do
+  it "has a version number" do
+    expect(Revolution::VERSION).not_to be nil
+  end
+
+  it "does something useful" do
+    expect(false).to eq(true)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,14 @@
+require "bundler/setup"
+require "revolution"
+
+RSpec.configure do |config|
+  # Enable flags like --only-failures and --next-failure
+  config.example_status_persistence_file_path = ".rspec_status"
+
+  # Disable RSpec exposing methods globally on `Module` and `main`
+  config.disable_monkey_patching!
+
+  config.expect_with :rspec do |c|
+    c.syntax = :expect
+  end
+end


### PR DESCRIPTION
Used `bundle gem` to generate and update package files:
- /lib/revolution/ source file stubs
- /spec/ documentation stubs
- Rakefile
- Gemfile
- .travis.yml

Updated .gitignore with `bundle gem` recommendations.

For more information see: https://bundler.io/v1.13/guides/creating_gem