### PR TITLE
Configure Bundler to allow use of rake, update README, fix formatting

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,3 +1,0 @@
----
-BUNDLE_PATH: "vendor/bundle"
-BUNDLE_DISABLE_SHARED_GEMS: "true"

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
+
 source 'https://rubygems.org'
 
-gem 'fpm-cookery', :git => 'https://github.com/bernd/fpm-cookery.git', :branch => 'master'
+gem 'fpm-cookery', git: 'https://github.com/bernd/fpm-cookery.git',
+                   branch: 'master'
+gem 'rake'
+gem 'rspec'
 gem 'rubocop'
 gem 'xmlrpc'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,6 +25,7 @@ GEM
     childprocess (0.7.1)
       ffi (~> 1.0, >= 1.0.11)
     clamp (1.0.1)
+    diff-lcs (1.3)
     dotenv (2.2.1)
     facter (2.5.1)
     ffi (1.9.18)
@@ -64,6 +65,19 @@ GEM
     rainbow (2.2.2)
       rake
     rake (12.1.0)
+    rspec (3.6.0)
+      rspec-core (~> 3.6.0)
+      rspec-expectations (~> 3.6.0)
+      rspec-mocks (~> 3.6.0)
+    rspec-core (3.6.0)
+      rspec-support (~> 3.6.0)
+    rspec-expectations (3.6.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.6.0)
+    rspec-mocks (3.6.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.6.0)
+    rspec-support (3.6.0)
     rubocop (0.49.1)
       parallel (~> 1.10)
       parser (>= 2.3.3.1, < 3.0)
@@ -86,6 +100,8 @@ PLATFORMS
 
 DEPENDENCIES
   fpm-cookery!
+  rake
+  rspec
   rubocop
   xmlrpc
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,18 @@ $ gem install bundler
 $ bundle install
 ```
 
+Then run the Rakefile inside the bundled environment:
+
+```
+$ bundle exec rake
+```
+
+Optionally you can turn on tracing with the `-t` flag:
+
+```
+$ bundle exec rake -t
+```
+
 ## License
 
 Licensed under either of

--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,9 @@
-require "bundler/gem_tasks"
-require "rspec/core/rake_task"
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'bundler/gem_tasks'
+require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec)
 
-task :default => :spec
+task default: :spec

--- a/revolution.gemspec
+++ b/revolution.gemspec
@@ -1,0 +1,35 @@
+# coding: utf-8
+# frozen_string_literal: true
+
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'revolution/version'
+
+Gem::Specification.new do |spec|
+  spec.name    = 'revolution'
+  spec.version = Revolution::VERSION
+
+  spec.summary     = 'TODO: Write a short summary, because Rubygems requires one.'
+  spec.description = 'TODO: Write a longer description or delete this line.'
+  spec.homepage    = "TODO: Put your gem's website or public repo URL here."
+
+  # Prevent pushing this gem to RubyGems.org. To allow pushes either
+  # set the 'allowed_push_host' to allow pushing to a single host
+  # or delete this section to allow pushing to any host.
+  if spec.respond_to?(:metadata)
+    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
+  else
+    raise 'RubyGems 2.0 or newer is required to protect against public gem pushes.'
+  end
+
+  spec.files         = `git ls-files -z`.split("\x0").reject do |f|
+    f.match(%r{^(test|spec|features)/})
+  end
+  spec.bindir        = 'exe'
+  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.require_paths = ['lib']
+
+  spec.add_development_dependency 'bundler', '~> 1.15'
+  spec.add_development_dependency 'rake', '~> 10.0'
+  spec.add_development_dependency 'rspec', '~> 3.0'
+end

--- a/spec/revolution_spec.rb
+++ b/spec/revolution_spec.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 RSpec.describe Revolution do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,6 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'bundler/setup'
 require 'revolution'
 


### PR DESCRIPTION
Deleted `.bundle/config` directory because it was breaking rake. See: https://stackoverflow.com/a/44575964

Updated Gemfile to include rake and fixed formatting.

Added gemspec file generated from `bundle gem`.

Added directions for using rake in the README.

Added shebang and magic comments, fixed formatting:
- Gemfile
- Rakefile
- spec/spec_helper.rb
- spec/revolution_spec.rb