### PR TITLE
Load project/package data from top-level directory

### DIFF
--- a/lib/revolution/project.rb
+++ b/lib/revolution/project.rb
@@ -13,8 +13,16 @@ def json_inspect(path)
     json   = stdout.read
     err    = stderr.read
     status = wait_thr.value
-    puts err unless status.exitstatus.zero?
-    return JSON.parse(json)
+    # puts err unless status.exitstatus.zero?
+    begin
+      data = JSON.parse(json)
+    rescue JSON::ParserError
+      # this should never happen
+      # should only be called when there's a valid recipe file
+      # but it's here for testing
+      return nil
+    end
+    return data
   end
 end
 

--- a/lib/revolution/project.rb
+++ b/lib/revolution/project.rb
@@ -26,10 +26,25 @@ def json_inspect(path)
   end
 end
 
-def load_projects(recipe_path)
-  # go through all directories in recipe_path
-  # if directory contains recipe.rb file, it's a project
 
+# Takes in path of directory containing all packages
+# Returns a list of Project objects populated with project and package data
+def load_projects(base_path)
+  projects = []
+  subdirs  = []
+  root = Dir.pwd
+  # Get subdirectories immediately inside of base_path
+  if Dir.exist?(base_path)
+    Dir.chdir(base_path)
+    subdirs = Dir.glob('*/')
+    Dir.chdir(root)
+  end
+
+  subdirs.each do |subpath|
+    path = base_path + subpath
+    projects.push(Project.new(path)) if File.exist?(path + '/recipe.rb')
+  end
+  projects
 end
 
 class Project

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -21,7 +21,15 @@ end
 
 describe 'load_projects' do
   context 'when passed a valid directory containing recipes' do
-    it 'returns a list of projects'
+    before(:all) do
+      @projects = load_projects('examples/')
+    end
+    it 'returns an array' do
+      expect(@projects).to be_an Array
+    end
+    it 'returns an array of one or more Project objects' do
+      expect(@projects[0]).to be_a Project
+    end
   end
 end
 

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -5,7 +5,7 @@ require 'rspec'
 require 'revolution/project'
 
 describe 'Project' do
-  context 'project with one recipe and no dependencies' do
+  context 'project with one package' do
     before(:all) do
       @proj = Project.new('examples/golang')
     end
@@ -22,32 +22,12 @@ describe 'Project' do
       it 'returns nil' do
         expect(@proj.chain_recipes).to be nil
       end
-
-      describe 'Package' do
-        context 'package with no dependencies' do
-          before(:all) do
-            @go = @proj.packages[0]
-          end
-
-          describe '#initialize' do
-            it 'returns a Package object' do
-              expect(@go).to be_a Project::Package
-            end
-          end
-          describe '#depends?' do
-            it 'returns false' do
-              expect(@go.depends?).to be false
-            end
-          end
-        end
-      end
-
     end
   end
 
-  context 'project with one package that has dependencies' do
+  context 'project with multiple recipes' do
     before(:all) do
-      @proj = Project.new('examples/package-with-deps')
+      @proj = Project.new('examples/project-chain-recipes')
     end
 
     describe '#initialize' do
@@ -60,46 +40,44 @@ describe 'Project' do
     end
 
     describe '#chain_recipes' do
-      it 'returns nil' do
-        expect(@proj.chain_recipes).to be nil
-      end
-      describe 'Package' do
-        context 'package with no dependencies' do
-          before(:all) do
-            @pkg = @proj.packages[0]
-          end
-          describe '#initialize' do
-            it 'returns a Package object' do
-              expect(@pkg).to be_a Project::Package
-            end
-          end
-          describe '#depends?' do
-            it 'returns true' do
-              expect(@pkg.depends?).to be true
-            end
-          end
-        end
+      it 'returns a list of length 1' do
+        expect(@proj.chain_recipes.length).to be 1
       end
     end
+  end
+end
 
-    context 'project with multiple recipes' do
-      before(:all) do
-        @proj = Project.new('examples/project-chain-recipes')
+describe 'Package' do
+  context 'package with no dependencies' do
+    before(:all) do
+      @go = Package.new('examples/golang')
+    end
+
+    describe '#initialize' do
+      it 'returns a Package object' do
+        expect(@go).to be_a Package
       end
-
-      describe '#initialize' do
-        it 'returns a Project object' do
-          expect(@proj).to be_a Project
-        end
-        it 'populates @data' do
-          expect(@proj.data['name']).not_to be nil
-        end
+    end
+    describe '#depends?' do
+      it 'returns false' do
+        expect(@go.depends?).to be false
       end
+    end
+  end
 
-      describe '#chain_recipes' do
-        it 'returns a list of length 1' do
-          expect(@proj.chain_recipes.length).to be 1
-        end
+  context 'package with dependencies' do
+    before(:all) do
+      @pkg = Package.new('examples/package-with-deps')
+    end
+
+    describe '#initialize' do
+      it 'returns a Package object' do
+        expect(@pkg).to be_a Package
+      end
+    end
+    describe '#depends?' do
+      it 'returns true' do
+        expect(@pkg.depends?).to be true
       end
     end
   end

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -4,6 +4,27 @@
 require 'rspec'
 require 'revolution/project'
 
+describe 'json_inspect' do
+  context 'when given valid package directory' do
+    it 'returns hash object containing json data' do
+      path = 'examples/golang'
+      expect(json_inspect(path)).to be_a Hash
+    end
+  end
+  context 'when given an invalid package directory' do
+    it 'returns nil' do
+      path = Dir.pwd
+      expect(json_inspect(path)).to be nil
+    end
+  end
+end
+
+describe 'load_projects' do
+  context 'when passed a valid directory containing recipes' do
+    it 'returns a list of projects'
+  end
+end
+
 describe 'Project' do
   context 'project with one package' do
     before(:all) do

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -4,17 +4,17 @@
 require 'rspec'
 require 'revolution/project'
 
-describe 'json_inspect' do
-  context 'when given valid package directory' do
-    it 'returns hash object containing json data' do
+describe 'inspect_recipe' do
+  context 'when passed a valid base directory containing recipe directories' do
+    it 'returns hash object containing recipe data' do
       path = 'examples/golang'
-      expect(json_inspect(path)).to be_a Hash
+      expect(inspect_recipe(path)).to be_a Hash
     end
   end
   context 'when given an invalid package directory' do
     it 'returns nil' do
       path = Dir.pwd
-      expect(json_inspect(path)).to be nil
+      expect(inspect_recipe(path)).to be nil
     end
   end
 end
@@ -34,7 +34,7 @@ describe 'load_projects' do
 end
 
 describe 'Project' do
-  context 'project with one package' do
+  context 'project with one recipe' do
     before(:all) do
       @proj = Project.new('examples/golang')
     end


### PR DESCRIPTION
I expect this PR to include the following changes:
- [X] Un-nest Package from Project class
- [X] Factor out `json_inspect` function
- [x] Add `load_projects` function that reads in base path and returns list of Project objects