### PR TITLE
Update gemspec, Gemfile, Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ rvm:
 before_install:
  - sudo apt-get -qq update
  - sudo apt-get install -y rpm createrepo expect
- - gem install bundler -v 1.15.4
+ - gem install bundler -v 1.16.1
 
 script:
   - bundle exec rubocop

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,6 @@
 
 source 'https://rubygems.org'
 
-gem 'aws-sdk', '~> 3'
 gem 'fpm-cookery', '~> 0.33.0',
     git:    'https://github.com/bernd/fpm-cookery.git',
     branch: 'master'
@@ -10,6 +9,5 @@ gem 'rake', '~> 12.1.0'
 gem 'rspec', '~> 3.6.0'
 gem 'rubocop', '~> 0.49.1'
 gem 'rugged', '~> 0.26.0'
-gem 'thor', '~> 0.20.0'
 gem 'xmlrpc', '~> 0.3.0'
 gemspec

--- a/revolution.gemspec
+++ b/revolution.gemspec
@@ -25,4 +25,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'bundler', '~> 1.15'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
+  spec.add_development_dependency 'thor', '~> 0.20.0'
+  spec.add_development_dependency 'aws-sdk', '~> 3'
+  spec.add_development_dependency 'fpm-cookery', '~> 0.33.0'
 end


### PR DESCRIPTION
In order for other projects to use the Revolution gem, I'm updating the gemspec to include aws-sdk and thor in the gem build. Since the Gemfile references the gemspec, I can remove those two dependencies there.

Updating the Bundler Travis version for consistency across environments.